### PR TITLE
Allow custom port via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Konquest Admin
+
+Simple Node.js server for serving static files.
+
+## Configuration
+
+- `PORT`: Port number for the server. Defaults to `3000` if the `PORT` environment variable is not set.
+
+## Usage
+
+Run the server with:
+
+```bash
+npm start
+```
+
+You can specify a different port:
+
+```bash
+PORT=8080 npm start
+```

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 
-const PORT = 3000; // Você pode escolher outra porta se preferir
+const PORT = process.env.PORT || 3000; // Você pode escolher outra porta se preferir ou definir via variável de ambiente
 
 const mimeTypes = {
     '.html': 'text/html',


### PR DESCRIPTION
## Summary
- configure server to read `PORT` from environment or default to 3000
- add project README with port configuration instructions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684195dd8a1083219251d91d7dcace42