### PR TITLE
Fix pathname parsing for static file requests

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,8 +24,9 @@ const server = http.createServer((req, res) => {
     // Define o caminho base para os arquivos estáticos
     const basePath = path.join(__dirname, 'public');
     
-    // Constrói o caminho do arquivo solicitado
-    let filePath = path.join(basePath, req.url === '/' ? 'index.html' : req.url);
+    // Constrói o caminho do arquivo solicitado de forma segura, ignorando query strings
+    const { pathname } = new URL(req.url, 'http://localhost');
+    let filePath = path.join(basePath, pathname === '/' ? 'index.html' : pathname);
 
     // Verifica a extensão do arquivo para definir o Content-Type
     const extname = String(path.extname(filePath)).toLowerCase();


### PR DESCRIPTION
## Summary
- ignore query strings when resolving static file paths

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684195d596388321adbab1088d07e5de