### PR TITLE
Atualiza cabeçalhos e remove controles de filtros

### DIFF
--- a/grupos/interno.html
+++ b/grupos/interno.html
@@ -16,6 +16,9 @@
                 <span class="material-icons-outlined">search</span>
                 <input type="text" id="grupo-header-search" placeholder="Buscar...">
             </div>
+            <button class="filter-button" title="Filtrar" id="grupo-header-filter">
+                <span class="material-icons-outlined">filter_list</span>
+            </button>
         </div>
         <button class="header-button icon-btn" id="btnSettings" title="Configurações" style="margin-left:auto;"><span class="material-icons-outlined">settings</span></button>
     </div>

--- a/grupos/interno.js
+++ b/grupos/interno.js
@@ -52,7 +52,7 @@ const usuariosMock = [
 
 function renderTabelaUsuarios(filtro = '') {
     const usuarios = usuariosMock.filter(u => u.nome.toLowerCase().includes(filtro.toLowerCase()));
-    let html = `<div class="controls"><button class="btn-icon" id="btnFiltroUsuarios" title="Filtros"><span class="material-icons-outlined">filter_list</span></button></div>
+    let html = `
         <table><thead><tr><th><input type="checkbox" id="checkAllUsuarios"></th><th></th><th>Nome</th><th>Cargo</th><th>Inclusão no grupo</th><th></th></tr></thead><tbody>
         ${usuarios.length === 0 ? `<tr><td colspan="6" style="text-align:center; color:#aaa;">Nenhum usuário encontrado.</td></tr>` :
             usuarios.map((u, idx) => `
@@ -73,10 +73,6 @@ function renderTabelaUsuarios(filtro = '') {
     const checks = document.querySelectorAll('.checkUsuario');
     checkAll.addEventListener('change', e => {
         checks.forEach(c => c.checked = checkAll.checked);
-    });
-    // Filtro (mock)
-    document.getElementById('btnFiltroUsuarios').addEventListener('click', () => {
-        alert('Abrir filtros (mock)');
     });
     // Menu de ações (mock)
     document.querySelectorAll('.btn-menu').forEach((btn, idx) => {
@@ -106,7 +102,7 @@ const canaisMock = [
 
 function renderTabelaCursos(filtro = '') {
     const cursos = cursosMock.filter(c => c.nome.toLowerCase().includes(filtro.toLowerCase()));
-    let html = `<div class="controls"></div>
+    let html = `
         <table><thead><tr><th></th><th>Nome</th><th>Tipo</th><th>Status</th><th>Inclusão no grupo</th><th></th></tr></thead><tbody>
         ${cursos.length === 0 ? `<tr><td colspan="6" style="text-align:center; color:#aaa;">Nenhum curso encontrado.</td></tr>` :
             cursos.map(c => `
@@ -131,7 +127,7 @@ function renderTabelaCursos(filtro = '') {
 
 function renderTabelaTrilhas(filtro = '') {
     const trilhas = trilhasMock.filter(t => t.nome.toLowerCase().includes(filtro.toLowerCase()));
-    let html = `<div class="controls"></div>
+    let html = `
         <table><thead><tr><th></th><th>Nome</th><th>Status</th><th>Inclusão no grupo</th><th></th></tr></thead><tbody>
         ${trilhas.length === 0 ? `<tr><td colspan="5" style="text-align:center; color:#aaa;">Nenhuma trilha encontrada.</td></tr>` :
             trilhas.map(t => `
@@ -155,7 +151,7 @@ function renderTabelaTrilhas(filtro = '') {
 
 function renderTabelaEventos(filtro = '') {
     const eventos = eventosMock.filter(ev => ev.nome.toLowerCase().includes(filtro.toLowerCase()));
-    let html = `<div class="controls"></div>
+    let html = `
         <table><thead><tr><th></th><th>Nome</th><th>Tipo</th><th>Data do evento</th><th>Status</th><th>Inclusão no grupo</th><th></th></tr></thead><tbody>
         ${eventos.length === 0 ? `<tr><td colspan="7" style="text-align:center; color:#aaa;">Nenhum evento encontrado.</td></tr>` :
             eventos.map(ev => `
@@ -181,7 +177,7 @@ function renderTabelaEventos(filtro = '') {
 
 function renderTabelaCanais(filtro = '') {
     const canais = canaisMock.filter(c => c.nome.toLowerCase().includes(filtro.toLowerCase()));
-    let html = `<div class="controls"></div>
+    let html = `
         <table><thead><tr><th></th><th>Nome</th><th>Tipo</th><th>Inclusão no grupo</th><th></th></tr></thead><tbody>
         ${canais.length === 0 ? `<tr><td colspan="5" style="text-align:center; color:#aaa;">Nenhum canal encontrado.</td></tr>` :
             canais.map(c => `
@@ -205,7 +201,7 @@ function renderTabelaCanais(filtro = '') {
 
 // Estrutura básica para as outras abas (cursos, trilhas, eventos, canais)
 function renderTabelaPlaceholder(aba, label) {
-    document.getElementById('aba-' + aba).innerHTML = `<div class="controls"><div style="padding:32px; text-align:center; color:#bbb;">Nenhum ${label} vinculado.</div></div>`;
+    document.getElementById('aba-' + aba).innerHTML = `<div style="padding:32px; text-align:center; color:#bbb;">Nenhum ${label} vinculado.</div>`;
 }
 
 // Render inicial

--- a/js/script.js
+++ b/js/script.js
@@ -115,7 +115,7 @@ function renderGenericTable(sectionId, data, allColsDefinition) {
     let placeholderText = "Buscar"; let sectionFriendlyName = sectionId.replace(/matriculas_|-/g, ' ').replace(/\b\w/g, l => l.toUpperCase()).trim(); placeholderText = `Buscar em ${sectionFriendlyName}...`;
     const itemIconName = sectionIcons[sectionId] || 'article';
     const columnsToRenderInHeader = allColsDefinition.filter(col => { if (col.key === 'acoes') return false; return visibleColumnsState[sectionId] ? visibleColumnsState[sectionId][col.key] !== false : true; });
-    let tableHTML = `<div class="controls"><button class="filter-button" title="Filtrar" onclick="alert('Filtro clicado para ${sectionFriendlyName}')"><span class="material-icons-outlined">filter_list</span></button></div><table id="table-${sectionId}"><thead><tr><th class="cell-checkbox"><input type="checkbox" class="table-checkbox" id="selectAll-${sectionId}" title="Selecionar Todos"></th>`;
+    let tableHTML = `<table id="table-${sectionId}"><thead><tr><th class="cell-checkbox"><input type="checkbox" class="table-checkbox" id="selectAll-${sectionId}" title="Selecionar Todos"></th>`;
     columnsToRenderInHeader.forEach(col => { tableHTML += `<th>${col.label}</th>`; });
     tableHTML += `<th style="text-align: right; position:relative;"><div class="table-header-actions"><button class="btn-icon" id="tableSettingsBtn-${sectionId}" title="Configurar Colunas"><span class="material-icons-outlined">settings</span></button>${renderColumnToggleDropdown(sectionId, allColsDefinition)}</div></th>`;
     tableHTML += `</tr></thead><tbody>`;
@@ -125,7 +125,7 @@ function renderGenericTable(sectionId, data, allColsDefinition) {
 }
 
 function renderContentTabs(sectionType) { /* ... (Idêntico) ... */ }
-renderContentTabs = function(sectionType) { let contentTabsConfig = []; let defaultTabId = ''; if (sectionType === 'gestao-conteudos') { contentTabsConfig = [ { id: 'cursos', label: 'Cursos', icon: 'school' }, { id: 'trilhas', label: 'Trilhas', icon: 'signpost' }, { id: 'eventos', label: 'Eventos', icon: 'event' }, { id: 'canais', label: 'Canais', icon: 'tv' }, { id: 'pulses', label: 'Pulses', icon: 'campaign' } ]; defaultTabId = 'cursos'; } else if (sectionType === 'matriculas') { contentTabsConfig = [ { id: 'matriculas_cursos', label: 'Cursos', icon: 'school' }, { id: 'matriculas_trilhas', label: 'Trilhas', icon: 'signpost' }, { id: 'matriculas_eventos', label: 'Eventos', icon: 'event' } ]; defaultTabId = 'matriculas_cursos'; } const isValidCurrentTab = contentTabsConfig.some(tab => tab.id === currentActiveContentTab); if (!isValidCurrentTab && defaultTabId) { currentActiveContentTab = defaultTabId; } let html = `<div class="content-tabs-container"> <div class="content-tabs">`; contentTabsConfig.forEach(tab => { html += `<div class="tab-item ${tab.id === currentActiveContentTab ? 'active' : ''}" data-tab="${tab.id}"><span class="material-icons-outlined nav-icon-md">${tab.icon}</span> ${tab.label}</div>`; }); html += `</div> <div class="content-tab-actions"><button class="header-button" id="contentCreateButton" title="Criar Novo"><span class="material-icons-outlined">add</span></button></div> </div>`; html += '<div class="tab-content-area">'; contentTabsConfig.forEach(tab => { html += `<div class="tab-content ${tab.id === currentActiveContentTab ? 'active' : ''}" id="tab-content-${tab.id}"></div>`; }); html += '</div>'; return html; }
+renderContentTabs = function(sectionType) { let contentTabsConfig = []; let defaultTabId = ''; if (sectionType === 'gestao-conteudos') { contentTabsConfig = [ { id: 'cursos', label: 'Cursos', icon: 'school' }, { id: 'trilhas', label: 'Trilhas', icon: 'signpost' }, { id: 'eventos', label: 'Eventos', icon: 'event' }, { id: 'canais', label: 'Canais', icon: 'tv' }, { id: 'pulses', label: 'Pulses', icon: 'campaign' } ]; defaultTabId = 'cursos'; } else if (sectionType === 'matriculas') { contentTabsConfig = [ { id: 'matriculas_cursos', label: 'Cursos', icon: 'school' }, { id: 'matriculas_trilhas', label: 'Trilhas', icon: 'signpost' }, { id: 'matriculas_eventos', label: 'Eventos', icon: 'event' } ]; defaultTabId = 'matriculas_cursos'; } const isValidCurrentTab = contentTabsConfig.some(tab => tab.id === currentActiveContentTab); if (!isValidCurrentTab && defaultTabId) { currentActiveContentTab = defaultTabId; } let html = `<div class="content-tabs-container"> <div class="content-tabs">`; contentTabsConfig.forEach(tab => { html += `<div class="tab-item ${tab.id === currentActiveContentTab ? 'active' : ''}" data-tab="${tab.id}"><span class="material-icons-outlined nav-icon-md">${tab.icon}</span> ${tab.label}</div>`; }); html += `</div>  </div>`; html += '<div class="tab-content-area">'; contentTabsConfig.forEach(tab => { html += `<div class="tab-content ${tab.id === currentActiveContentTab ? 'active' : ''}" id="tab-content-${tab.id}"></div>`; }); html += '</div>'; return html; }
 
 function renderIntegrationTabs() { /* ... (Idêntico) ... */ }
 renderIntegrationTabs = function() { const filterTabsConfig = [ { id: 'todas', label: `Todas (${integrationsData.length})` }, { id: 'ativas', label: `Ativas (${integrationsData.filter(i => i.active).length})` }, { id: 'inativas', label: `Inativas (${integrationsData.filter(i => !i.active).length})` } ]; let html = `<div class="content-tabs-container"><div class="content-tabs">`; filterTabsConfig.forEach(tab => { html += `<div class="tab-item ${tab.id === currentIntegrationFilter ? 'active' : ''}" data-filter="${tab.id}">${tab.label}</div>`; }); html += `</div><div class="content-tab-actions"><button class="header-button" id="newIntegrationButton" title="Nova Integração"><span class="material-icons-outlined">add</span></button></div></div>`; html += `<div class="controls" style="padding: 12px 16px 12px 24px; border-bottom: 1px solid var(--border-color);"><div class="search-input-container"><span class="material-icons-outlined">search</span><input type="text" placeholder="Buscar integrações..." id="search-integrations"></div></div>`; html += '<div class="integrations-grid-wrapper"><div class="integrations-grid" id="integrationsGrid"></div></div>'; return html; }
@@ -463,32 +463,14 @@ function loadSectionContent(sectionId) {
                         <span class="material-icons-outlined">search</span>
                         <input type="text" id="header-search-${sectionId}" placeholder="Buscar...">
                     </div>
+                    <button class="filter-button" title="Filtrar" id="header-filter-${sectionId}">
+                        <span class="material-icons-outlined">filter_list</span>
+                    </button>
                 </div>
             </div>`;
         contentPanel.innerHTML = headerHtml + renderContentTabs(sectionId);
         attachHeaderSearchListener(sectionId);
         loadTabContent(currentActiveContentTab); // Carrega a aba ativa
-        const contentCreateButton = document.getElementById('contentCreateButton');
-        if (contentCreateButton) {
-            contentCreateButton.addEventListener('click', () => {
-                let createTypeFriendly = 'Item';
-                if (sectionId === 'gestao-conteudos') {
-                    switch(currentActiveContentTab) {
-                        case 'cursos': createTypeFriendly = 'Curso (Conteúdo)'; break; case 'trilhas': createTypeFriendly = 'Trilha (Conteúdo)'; break;
-                        case 'canais': createTypeFriendly = 'Canal'; break; case 'pulses': createTypeFriendly = 'Pulse'; break;
-                        case 'eventos': createTypeFriendly = 'Evento (Conteúdo)'; break;
-                        default: createTypeFriendly = currentActiveContentTab.charAt(0).toUpperCase() + currentActiveContentTab.slice(1); break;
-                    }
-                } else if (sectionId === 'matriculas') {
-                     switch(currentActiveContentTab) {
-                        case 'matriculas_cursos': createTypeFriendly = 'Matrícula em Curso'; break; case 'matriculas_trilhas': createTypeFriendly = 'Matrícula em Trilha'; break;
-                        case 'matriculas_eventos': createTypeFriendly = 'Inscrição em Evento'; break;
-                        default: createTypeFriendly = currentActiveContentTab.replace('matriculas_', '').charAt(0).toUpperCase() + currentActiveContentTab.replace('matriculas_', '').slice(1); break;
-                    }
-                }
-                alert(`Botão "+" (Abas) Clicado! Criar: ${createTypeFriendly}.`);
-            });
-        }
         document.querySelectorAll('.tab-item[data-tab]').forEach(tabElement => {
             tabElement.addEventListener('click', function() {
                 document.querySelectorAll('.tab-item[data-tab]').forEach(t => t.classList.remove('active'));
@@ -522,6 +504,9 @@ function loadSectionContent(sectionId) {
                         <span class="material-icons-outlined">search</span>
                         <input type="text" id="header-search-${sectionId}" placeholder="Buscar...">
                     </div>
+                    <button class="filter-button" title="Filtrar" id="header-filter-${sectionId}">
+                        <span class="material-icons-outlined">filter_list</span>
+                    </button>
                 </div>
                 <div class="content-header-actions">
                     <button class="header-button" id="directCreateButton" title="Criar Novo ${sectionTitle}">


### PR DESCRIPTION
## Summary
- remove `<div class="controls">` com botão de filtro das renderizações de tabelas
- adiciona botão de filtro ao lado do campo de busca no cabeçalho
- remove botão `contentCreateButton` e seu listener
- ajusta página de grupos para novo layout de cabeçalho

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841a646a40c832194391255a92fe431