### PR TITLE
Improve search bar with inline filter icon

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -187,12 +187,15 @@ body {
     border: 1px solid var(--border-color);
     border-radius: 20px;
 }
-.search-input-container .material-icons-outlined {
+.search-input-container > .material-icons-outlined {
     color: var(--sidebar-icon-color);
     margin-right: 8px;
     font-size: 22px;
 }
-.controls input[type="text"] {
+.search-input-container .filter-button .material-icons-outlined {
+    margin-right: 0;
+}
+.search-input-container input[type="text"] {
     border: none;
     background: none;
     padding: 0;
@@ -200,17 +203,17 @@ body {
     flex-grow: 1;
     outline: none;
 }
-.controls .filter-button {
+.search-input-container .filter-button {
     background: none;
     border: none;
-    color: var(--primary-color);
+    color: var(--sidebar-icon-color);
     cursor: pointer;
     transition: background-color 0.2s;
 }
-.controls .filter-button:hover {
+.search-input-container .filter-button:hover {
     background-color: rgba(0,0,0,0.08);
 }
-.controls .filter-button .material-icons-outlined { font-size: 22px; }
+.search-input-container .filter-button .material-icons-outlined { font-size: 22px; }
 
 table { width: 100%; border-collapse: collapse; table-layout: fixed; }
 th, td {
@@ -378,6 +381,7 @@ table thead:hover .table-header-actions { visibility: visible; opacity: 1; trans
 .content-tab-actions .header-button,
 .content-header-no-tabs .content-header-actions .header-button,
 .controls .filter-button,
+.search-input-container .filter-button,
 .btn-icon.more {
   width: 36px;
   height: 36px;

--- a/grupos/interno.css
+++ b/grupos/interno.css
@@ -67,18 +67,31 @@
     border: 1px solid var(--border-color);
     border-radius: 20px;
 }
-.search-input-container .material-icons-outlined {
+.search-input-container > .material-icons-outlined {
     color: var(--sidebar-icon-color);
     margin-right: 8px;
     font-size: 22px;
 }
-.controls input[type="text"] {
+.search-input-container .filter-button .material-icons-outlined {
+    margin-right: 0;
+}
+.search-input-container input[type="text"] {
     border: none;
     background: none;
     padding: 0;
     font-size: 0.9em;
     flex-grow: 1;
     outline: none;
+}
+.search-input-container .filter-button {
+    background: none;
+    border: none;
+    color: var(--sidebar-icon-color);
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+.search-input-container .filter-button:hover {
+    background-color: rgba(0,0,0,0.08);
 }
 /* TABELA */
 table {

--- a/grupos/interno.html
+++ b/grupos/interno.html
@@ -15,10 +15,10 @@
             <div class="search-input-container">
                 <span class="material-icons-outlined">search</span>
                 <input type="text" id="grupo-header-search" placeholder="Buscar...">
+                <button class="filter-button icon-btn" title="Filtrar" id="grupo-header-filter">
+                    <span class="material-icons-outlined">filter_list</span>
+                </button>
             </div>
-            <button class="filter-button" title="Filtrar" id="grupo-header-filter">
-                <span class="material-icons-outlined">filter_list</span>
-            </button>
         </div>
         <button class="header-button icon-btn" id="btnSettings" title="Configurações" style="margin-left:auto;"><span class="material-icons-outlined">settings</span></button>
     </div>

--- a/js/script.js
+++ b/js/script.js
@@ -359,8 +359,11 @@ function renderConfiguracoesComplementos() {
     let html = `
         <div class="complementos-search-bar" style="padding:0 16px 0 16px;">
             <div class="controls" style="margin-bottom:24px; border-bottom:none; padding: 16px 0 0 0;">
-                <div class="search-input-container" style="flex:1;"><span class="material-icons-outlined">search</span><input type="text" id="buscaComplementos" placeholder="Buscar integrações ou parceiros..."></div>
-                <button class="btn-icon" id="btnFiltroComplementos" title="Filtros"><span class="material-icons-outlined">filter_list</span></button>
+                <div class="search-input-container" style="flex:1;">
+                    <span class="material-icons-outlined">search</span>
+                    <input type="text" id="buscaComplementos" placeholder="Buscar integrações ou parceiros...">
+                    <button class="btn-icon filter-button" id="btnFiltroComplementos" title="Filtros"><span class="material-icons-outlined">filter_list</span></button>
+                </div>
             </div>
         </div>
         <div class="complementos-cards-area" style="padding:0 16px 32px 16px;">`;
@@ -462,10 +465,10 @@ function loadSectionContent(sectionId) {
                     <div class="search-input-container">
                         <span class="material-icons-outlined">search</span>
                         <input type="text" id="header-search-${sectionId}" placeholder="Buscar...">
+                        <button class="filter-button icon-btn" title="Filtrar" id="header-filter-${sectionId}">
+                            <span class="material-icons-outlined">filter_list</span>
+                        </button>
                     </div>
-                    <button class="filter-button" title="Filtrar" id="header-filter-${sectionId}">
-                        <span class="material-icons-outlined">filter_list</span>
-                    </button>
                 </div>
             </div>`;
         contentPanel.innerHTML = headerHtml + renderContentTabs(sectionId);
@@ -503,10 +506,10 @@ function loadSectionContent(sectionId) {
                     <div class="search-input-container">
                         <span class="material-icons-outlined">search</span>
                         <input type="text" id="header-search-${sectionId}" placeholder="Buscar...">
+                        <button class="filter-button icon-btn" title="Filtrar" id="header-filter-${sectionId}">
+                            <span class="material-icons-outlined">filter_list</span>
+                        </button>
                     </div>
-                    <button class="filter-button" title="Filtrar" id="header-filter-${sectionId}">
-                        <span class="material-icons-outlined">filter_list</span>
-                    </button>
                 </div>`;
         if(sectionId !== 'grupos' && sectionId !== 'categorias') {
             headerHtml += `


### PR DESCRIPTION
## Summary
- integrate filter icon inside search bars
- clean up search input placeholder style
- apply material icon button look across pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841d5fd12148321b8f506e851f37fcd