### PR TITLE
Enhance add dropdown with icons and grouped actions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -69,6 +69,18 @@ body {
     padding: 10px 16px; cursor: pointer; font-size: 0.9rem; color: var(--text-color);
     border-radius: 4px;
 }
+.fab-dropdown .dropdown-icon {
+    margin-right: 8px;
+    width: 20px;
+    text-align: center;
+    vertical-align: middle;
+}
+.fab-dropdown .dropdown-divider {
+    height: 1px;
+    background: #f0f0f0;
+    margin: 4px 0;
+    border: none;
+}
 .fab-dropdown .dropdown-item:hover { background: var(--primary-light-color); color: var(--primary-color); }
 .sidebar.collapsed .add-button { width: 48px; margin-top: 4px; }
 

--- a/index.html
+++ b/index.html
@@ -22,19 +22,21 @@
                     <span class="material-icons-outlined">add</span>
                 </button>
                 <div class="fab-dropdown" id="addDropdown">
-                    <div class="dropdown-item">Matrículas</div>
-                    <div class="dropdown-item">Cursos</div>
-                    <div class="dropdown-item">Trilhas</div>
-                    <div class="dropdown-item">Eventos</div>
-                    <div class="dropdown-item">Canais</div>
-                    <div class="dropdown-item">Pulses</div>
-                    <div class="dropdown-item">Grupos</div>
-                    <div class="dropdown-item">Categorias</div>
-                    <div class="dropdown-item">Banners</div>
-                    <div class="dropdown-item">Sessões</div>
-                    <div class="dropdown-item">Campanhas</div>
-                    <div class="dropdown-item">Normativas</div>
-                    <div class="dropdown-item">Certificados</div>
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">how_to_reg</span>Matrículas</div>
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">class</span>Cursos</div>
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">conversion_path</span>Trilhas</div>
+                    <hr class="dropdown-divider">
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">event</span>Eventos</div>
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">forum</span>Canais</div>
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">insights</span>Pulses</div>
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">groups</span>Grupos</div>
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">label</span>Categorias</div>
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">collections</span>Banners</div>
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">splitscreen</span>Sessões</div>
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">campaign</span>Campanhas</div>
+                    <hr class="dropdown-divider">
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">gavel</span>Normativas</div>
+                    <div class="dropdown-item"><span class="material-icons-outlined dropdown-icon">verified</span>Certificados</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- show icons and divider lines on add dropdown menu

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842ee078228832194cbcec88389e813