### PR TITLE
Add sidebar theme toggle

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -26,6 +26,17 @@
     --nav-icon-margin-right: calc(var(--nav-text-start-position) - var(--nav-link-icon-container-start) - var(--nav-link-icon-container-width));
 }
 
+body.dark-theme {
+    --sidebar-bg: #202124;
+    --sidebar-text-color: #e8eaed;
+    --sidebar-icon-color: #e8eaed;
+    --sidebar-active-bg: #3c4043;
+    --sidebar-active-text: #fff;
+    --content-bg: #303134;
+    --text-color: #e8eaed;
+    --border-color: #5f6368;
+}
+
 * { box-sizing: border-box; margin: 0; padding: 0; }
 html { height: 100%; }
 body {

--- a/css/style.css
+++ b/css/style.css
@@ -116,17 +116,35 @@ body {
 .sidebar-nav ul li a.active .nav-icon-md { color: var(--sidebar-active-text); }
 
 .sidebar-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     padding: 12px var(--sidebar-header-h-padding);
-    border-top: 1px solid var(--border-color); 
+    border-top: 1px solid var(--border-color);
     flex-shrink: 0;
+    gap: 8px;
 }
 .sidebar-footer .exit-button {
-    display: flex; align-items: center; width: 100%;
+    display: flex; align-items: center;
     padding-left: var(--nav-link-icon-container-start);
     height: 40px; border-radius: 8px; background: none; border: none; cursor: pointer;
     color: var(--sidebar-text-color); text-decoration: none; font-size: 0.875rem;
     font-weight: 500; text-align: left;
 }
+.sidebar-footer .theme-toggle {
+    width: 40px;
+    height: 40px;
+    border: none;
+    background: none;
+    border-radius: 8px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--sidebar-icon-color);
+}
+.sidebar-footer .theme-toggle:hover,
+.sidebar-footer .exit-button:hover { background-color: #e8eaed; }
 .sidebar-footer .exit-button .nav-icon-md {
      margin-right: var(--nav-icon-margin-right);
     width: var(--nav-link-icon-container-width); text-align: center; color: var(--sidebar-icon-color);
@@ -158,6 +176,9 @@ body {
     justify-content: center; padding: 0; width: 48px; height: 48px; border-radius: 50%; margin: 0 auto;
 }
 .sidebar.collapsed .sidebar-footer .exit-button .nav-icon-md { margin: 0; font-size: 24px; width: auto;}
+.sidebar.collapsed .sidebar-footer .theme-toggle {
+    width: 48px; height: 48px; border-radius: 50%; margin: 0 auto; padding: 0;
+}
 
 .content-panel {
     flex-grow: 1; background-color: var(--content-bg);

--- a/index.html
+++ b/index.html
@@ -72,7 +72,10 @@
         <div class="sidebar-footer">
             <button class="exit-button" id="exitAdminButton" title="Sair da Área Administrativa">
                 <span class="material-icons-outlined nav-icon-md">logout</span>
-                <span class="nav-text">Sair da Administração</span>
+                <span class="nav-text">Sair</span>
+            </button>
+            <button class="theme-toggle" id="themeToggle" title="Alternar tema claro/escuro">
+                <span class="material-symbols-outlined">dark_mode</span>
             </button>
         </div>
     </aside>

--- a/js/script.js
+++ b/js/script.js
@@ -118,6 +118,7 @@ for (const sectionKey in allTableColumns) { visibleColumnsState[sectionKey] = {}
 const sidebar = document.getElementById('sidebar');
 const collapseButton = document.getElementById('collapseButton');
 const exitAdminButton = document.getElementById('exitAdminButton');
+const themeToggle = document.getElementById('themeToggle');
 const addButton = document.getElementById('addButton');
 const addDropdown = document.getElementById('addDropdown');
 const navLinks = document.querySelectorAll('.sidebar-nav .nav-link');
@@ -154,6 +155,13 @@ function handleHeaderOnCollapse() {
 }
 collapseButton.addEventListener('click', () => { sidebar.classList.toggle('collapsed'); handleHeaderOnCollapse(); });
 exitAdminButton.addEventListener('click', () => { alert('Saindo da Área Administrativa...'); });
+if(themeToggle){
+    themeToggle.addEventListener('click', () => {
+        const icon = themeToggle.querySelector('span');
+        document.body.classList.toggle('dark-theme');
+        icon.textContent = document.body.classList.contains('dark-theme') ? 'light_mode' : 'dark_mode';
+    });
+}
 if(addButton && addDropdown) {
     addButton.addEventListener('click', ev => {
         ev.stopPropagation();


### PR DESCRIPTION
## Summary
- add dark theme variables
- style sidebar footer to include theme toggle
- add theme toggle button in sidebar footer
- implement JS handler for toggling theme

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684306ee9a0c832183518ff550f07e88