### PR TITLE
Fix exit icon alignment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -127,9 +127,9 @@ body {
 .sidebar-footer .exit-button {
     display: flex; align-items: center;
     padding-left: var(--nav-link-icon-container-start);
-    height: 40px; border-radius: 8px; background: none; border: none; cursor: pointer;
+    height: 32px; border-radius: 8px; background: none; border: none; cursor: pointer;
     color: var(--sidebar-text-color); text-decoration: none; font-size: 0.875rem;
-    font-weight: 500; text-align: left;
+    font-weight: 500; text-align: left; margin-right: 12px;
 }
 .sidebar-footer .theme-toggle {
     width: 40px;


### PR DESCRIPTION
## Summary
- adjust sidebar exit button CSS so its icon matches other menu items

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843281687c88321b8efb06cffcae115