### PR TITLE
Improve dark theme

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -24,6 +24,10 @@
     --nav-link-icon-container-width: var(--sidebar-header-icon-area-width);
     --nav-text-start-position: calc(var(--sidebar-header-h-padding) + var(--sidebar-header-icon-area-width) + var(--sidebar-header-title-margin-left));
     --nav-icon-margin-right: calc(var(--nav-text-start-position) - var(--nav-link-icon-container-start) - var(--nav-link-icon-container-width));
+    --body-bg: var(--sidebar-bg);
+    --btn-hover-bg: rgba(0,0,0,0.08);
+    --menu-hover-bg: #e8eaed;
+    --row-hover-bg: #f5f5f5;
 }
 
 body.dark-theme {
@@ -32,16 +36,20 @@ body.dark-theme {
     --sidebar-icon-color: #e8eaed;
     --sidebar-active-bg: #3c4043;
     --sidebar-active-text: #fff;
-    --content-bg: #303134;
+    --content-bg: #202124;
     --text-color: #e8eaed;
     --border-color: #5f6368;
+    --body-bg: #303134;
+    --btn-hover-bg: rgba(255,255,255,0.1);
+    --menu-hover-bg: #3c4043;
+    --row-hover-bg: #3c4043;
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 html { height: 100%; }
 body {
     font-family: 'Roboto', sans-serif;
-    background-color: var(--sidebar-bg);
+    background-color: var(--body-bg);
     color: var(--text-color);
 }
 
@@ -65,4 +73,4 @@ body {
 }
 .btn-icon .material-icons-outlined,
 .btn-icon .material-symbols-outlined { font-size: 18px; }
-.btn-icon:hover { background-color: rgba(0,0,0,0.08); }
+.btn-icon:hover { background-color: var(--btn-hover-bg); }

--- a/css/style.css
+++ b/css/style.css
@@ -31,7 +31,7 @@ body {
 }
 .sidebar-header .header-button .material-icons-outlined,
 .sidebar-header .header-button .material-symbols-outlined { font-size: 24px; }
-.sidebar-header .header-button:hover { background-color: rgba(0,0,0,0.08); }
+.sidebar-header .header-button:hover { background-color: var(--btn-hover-bg); }
 .sidebar-header .admin-title {
     font-size: 1.25rem; font-weight: 500; color: var(--text-color);
     margin-right: auto; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
@@ -51,7 +51,7 @@ body {
 }
 .add-button .material-icons-outlined,
 .add-button .material-symbols-outlined { font-size: 24px; }
-.add-button:hover { background-color: rgba(0,0,0,0.08); }
+.add-button:hover { background-color: var(--btn-hover-bg); }
 .fab-dropdown {
     display: none;
     position: fixed;
@@ -111,7 +111,7 @@ body {
     text-align: center; color: var(--sidebar-icon-color);
     flex-shrink: 0; line-height: 1; display: inline-flex; align-items: center; justify-content: center;
 }
-.sidebar-nav ul li a:hover { background-color: #e8eaed; }
+.sidebar-nav ul li a:hover { background-color: var(--menu-hover-bg); }
 .sidebar-nav ul li a.active { background-color: var(--sidebar-active-bg); color: var(--sidebar-active-text); font-weight: 500; }
 .sidebar-nav ul li a.active .nav-icon-md { color: var(--sidebar-active-text); }
 
@@ -144,13 +144,13 @@ body {
     color: var(--sidebar-icon-color);
 }
 .sidebar-footer .theme-toggle:hover,
-.sidebar-footer .exit-button:hover { background-color: #e8eaed; }
+.sidebar-footer .exit-button:hover { background-color: var(--menu-hover-bg); }
 .sidebar-footer .exit-button .nav-icon-md {
      margin-right: var(--nav-icon-margin-right);
     width: var(--nav-link-icon-container-width); text-align: center; color: var(--sidebar-icon-color);
     flex-shrink: 0; line-height: 1; display: inline-flex; align-items: center; justify-content: center;
 }
-.sidebar-footer .exit-button:hover { background-color: #e8eaed; }
+.sidebar-footer .exit-button:hover { background-color: var(--menu-hover-bg); }
 
 .sidebar.collapsed { width: 70px; }
 .sidebar.collapsed .admin-title, .sidebar.collapsed .nav-text, .sidebar.collapsed .exit-button .nav-text { display: none; opacity: 0; width:0; }
@@ -238,7 +238,7 @@ body {
 .content-header-no-tabs .content-header-actions .header-button .material-icons-outlined,
 .content-header-no-tabs .content-header-actions .header-button .material-symbols-outlined { font-size: 24px; }
 .content-tab-actions .header-button:hover,
-.content-header-no-tabs .content-header-actions .header-button:hover { background-color: rgba(0,0,0,0.08); }
+.content-header-no-tabs .content-header-actions .header-button:hover { background-color: var(--btn-hover-bg); }
 
 .tab-content-area, .section-content-area { padding: 0; flex-grow: 1; overflow-y: auto; }
 .tab-content { display: none; }
@@ -286,7 +286,7 @@ body {
     transition: background-color 0.2s;
 }
 .search-input-container .filter-button:hover {
-    background-color: rgba(0,0,0,0.08);
+    background-color: var(--btn-hover-bg);
 }
 .search-input-container .filter-button .material-icons-outlined,
 .search-input-container .filter-button .material-symbols-outlined { font-size: 22px; }
@@ -299,7 +299,7 @@ th, td {
 }
 tr { border-bottom: 1px solid var(--border-color); }
 tr:last-child { border-bottom: none; }
-tr:hover { background-color: #f5f5f5; }
+tr:hover { background-color: var(--row-hover-bg); }
 
 table thead tr { position: relative; }
 th {
@@ -382,7 +382,7 @@ tr:hover .table-row-actions { visibility: visible; opacity: 1; transition-delay:
 .integration-card-footer .config-button { padding: 7px 14px; font-size: 0.97rem; background-color: #f1f3f4; color: var(--sidebar-text-color); border: none; border-radius: 6px; box-shadow: none; cursor: pointer; }
 .integration-card-footer .config-button .material-icons-outlined,
 .integration-card-footer .config-button .material-symbols-outlined { margin-right: 6px; font-size: 18px; }
-.integration-card-footer .config-button:hover { background-color: #e8eaed; }
+.integration-card-footer .config-button:hover { background-color: var(--btn-hover-bg); }
 .integration-card-toggle { position: relative; display: inline-block; width: 44px; height: 24px; }
 .integration-card-toggle input { display: none; }
 .integration-card-toggle .slider { position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0; background-color: #ccc; border-radius: 24px; transition: .4s; }
@@ -413,7 +413,7 @@ table thead:hover .table-header-actions { visibility: visible; opacity: 1; trans
     padding: 0; border-radius: 50%; width: 36px; height: 36px; 
     display: flex; align-items: center; justify-content: center;
 }
-.table-header-actions .header-button:hover { background-color: rgba(0,0,0,0.08); }
+.table-header-actions .header-button:hover { background-color: var(--btn-hover-bg); }
 .table-header-actions .header-button .material-icons-outlined,
 .table-header-actions .header-button .material-symbols-outlined { font-size: 20px; }
 
@@ -431,7 +431,7 @@ table thead:hover .table-header-actions { visibility: visible; opacity: 1; trans
     padding: 8px 16px; display: flex; align-items: center;
     cursor: pointer; font-size: 0.875rem; color: var(--text-color);
 }
-.column-toggle-dropdown .dropdown-item:hover { background-color: #f5f5f5; }
+.column-toggle-dropdown .dropdown-item:hover { background-color: var(--row-hover-bg); }
 .column-toggle-dropdown .dropdown-item input[type="checkbox"] { margin-right: 10px; cursor: pointer; accent-color: var(--primary-color); }
 .column-toggle-dropdown .dropdown-item label { cursor: pointer; flex-grow: 1; }
 
@@ -454,7 +454,7 @@ table thead:hover .table-header-actions { visibility: visible; opacity: 1; trans
   font-size: 22px;
 }
 .btn-icon.more:hover {
-  background-color: rgba(0,0,0,0.08);
+  background-color: var(--btn-hover-bg);
   color: var(--primary-color);
 }
 

--- a/grupos/interno.css
+++ b/grupos/interno.css
@@ -93,7 +93,7 @@
     transition: background-color 0.2s;
 }
 .search-input-container .filter-button:hover {
-    background-color: rgba(0,0,0,0.08);
+    background-color: var(--btn-hover-bg);
 }
 /* TABELA */
 table {
@@ -112,7 +112,7 @@ th {
 }
 tr { border-bottom: 1px solid var(--border-color); }
 tr:last-child { border-bottom: none; }
-tr:hover { background-color: #f5f5f5; }
+tr:hover { background-color: var(--row-hover-bg); }
 .btn-icon.delete:hover { color: #dc3545; }
 .status { padding: 4px 8px; border-radius: 15px; font-size: 0.8em; font-weight: 500; display: inline-block; white-space: normal;}
 @media (max-width: 700px) {


### PR DESCRIPTION
## Summary
- adjust dark mode variables for better contrast
- swap page and panel background colors
- make hover styles respect new theme variables

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684327866be48321acb03b15b8f47d84