### PR TITLE
Implement Quick Graph for store overview

### DIFF
--- a/grupos/interno.css
+++ b/grupos/interno.css
@@ -158,3 +158,12 @@ td:first-child, th:first-child { width: 36px; text-align: center; }
 input[type="checkbox"] { accent-color: var(--primary-color); width: 18px; height: 18px; }
 .tab-content { display: none; }
 .tab-content.active { display: block; } 
+
+/* Quick Graph Styles */
+.quick-graph { padding: 16px; border-bottom: 1px solid var(--border-color); background: var(--content-bg); }
+.quick-graph-title { margin-bottom: 8px; font-size: 1rem; }
+.quick-graph-bar { margin-bottom: 6px; }
+.quick-graph-label { display: block; font-size: 0.85rem; margin-bottom: 2px; }
+.quick-graph-bar-inner { height: 16px; background: var(--primary-color); color:#fff; border-radius: 4px; padding-left:4px; font-size: 0.75rem; line-height:16px; }
+.quick-graph-total { margin-top: 8px; font-weight: bold; text-align: right; font-size:0.9rem; }
+

--- a/grupos/interno.html
+++ b/grupos/interno.html
@@ -24,6 +24,7 @@
         </div>
         <button class="header-button icon-btn" id="btnSettings" title="Configurações" style="margin-left:auto;"><span class="material-icons-outlined">settings</span></button>
     </div>
+    <div id="quickGraphContainer" class="quick-graph"></div>
     <div class="content-tabs-container">
         <div class="content-tabs">
             <div class="tab-item active" data-aba="usuarios">Usuários vinculados</div>

--- a/grupos/interno.js
+++ b/grupos/interno.js
@@ -99,6 +99,15 @@ const canaisMock = [
     { id: 1, nome: 'Canal Novidades', tipo: 'Aberto', data: '2 de mai. de 2024', icon: 'hub' },
     { id: 2, nome: 'Canal Design', tipo: 'Fechado', data: '2 de mai. de 2024', icon: 'hub' },
 ];
+const storesData = [
+    { id: 1, nome: "Loja Central", usuarios: 34 },
+    { id: 2, nome: "Filial Norte", usuarios: 22 },
+    { id: 3, nome: "Filial Sul", usuarios: 18 },
+    { id: 4, nome: "Filial Leste", usuarios: 15 },
+    { id: 5, nome: "Filial Oeste", usuarios: 21 }
+];
+window.storesData = storesData;
+
 
 function renderTabelaCursos(filtro = '') {
     const cursos = cursosMock.filter(c => c.nome.toLowerCase().includes(filtro.toLowerCase()));
@@ -198,6 +207,17 @@ function renderTabelaCanais(filtro = '') {
         });
     });
 }
+function renderQuickGraph() {
+    const container = document.getElementById("quickGraphContainer");
+    if (!container) return;
+    const totalUsuarios = storesData.reduce((sum, s) => sum + s.usuarios, 0);
+    const bars = storesData.map(s => {
+        const pct = totalUsuarios ? (s.usuarios / totalUsuarios) * 100 : 0;
+        return `<div class="quick-graph-bar"><span class="quick-graph-label">${s.nome}</span><div class="quick-graph-bar-inner" style="width:${pct}%">${s.usuarios}</div></div>`;
+    }).join("");
+    container.innerHTML = `<h3 class="quick-graph-title">Visão rápida de Lojas</h3>${bars}<div class="quick-graph-total">Total: ${totalUsuarios}</div>`;
+}
+
 
 // Estrutura básica para as outras abas (cursos, trilhas, eventos, canais)
 function renderTabelaPlaceholder(aba, label) {
@@ -206,3 +226,4 @@ function renderTabelaPlaceholder(aba, label) {
 
 // Render inicial
 renderAba(currentTab, currentSearch);
+renderQuickGraph();


### PR DESCRIPTION
## Summary
- add Quick Graph container and styles to the group page
- include mock `storesData` dataset
- render Quick Graph with totals using the dataset

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68433162a94c8321a00a5720b898b371